### PR TITLE
Include PyEmpaq config file.

### DIFF
--- a/pyempaq.yaml
+++ b/pyempaq.yaml
@@ -1,0 +1,6 @@
+name: pomodorotk
+exec: 
+  entrypoint: ["-c", "from pomodorotk.pomodoro import main; main()"]
+dependencies:
+  - pydub
+  - ffmpeg-python


### PR DESCRIPTION
I saw your talk yesterday in the PyDay about packing this tool. I wanted to show an alternative way of doing it: [PyEmpaq](https://pyempaq.readthedocs.io/en/latest/).

For that I included the needed configuration file in the project, described here:

```
name: pomodorotk
exec: 
  entrypoint: ["-c", "from pomodorotk.pomodoro import main; main()"]
dependencies:
  - pydub
  - ffmpeg-python
```

It's quite self-descriptive. The `entrypoint` is a little bizarre but that's just to not change anything in the rest of the code. If you directly used PyEmpaq you wouldn't have needed to change the project structure in the first place. Or with current structure, adding a `__main__` in the source directory would also simplify this configuration file.

To pack it install somewhere PyEmpaq with pipx, fades or whatever and run it. For example:

```
cd /tmp
python3 -m venv env
source env/bin/activate
pip install pyempaq
pyempaq PATH-TO-POMODOROTK-PROJECT
```

That will leave you a `pomodorotk.pyz` file that you can take to any other machine with Python installed and just run it, no need to do anything else or teach other people to do anything with it more that calling it with Python.